### PR TITLE
feat: change default model to Kimi K2 on Groq

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,7 @@ export const MODELS = {
   "Qwen-3 (groq)": groqClient("qwen/qwen3-32b"),
 };
 
-export const DEFAULT_MODEL = "GPT-OSS (groq)";
+export const DEFAULT_MODEL = "Kimi K2 (groq)";
 
 export const MODERATION_MODEL = groqClient("openai/gpt-oss-safeguard-20b");
 


### PR DESCRIPTION
This PR changes the default model to Kimi K2 on Groq as requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default AI model selection to Kimi K2 (groq).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->