### PR TITLE
feat: use autocomplete for /model command

### DIFF
--- a/src/commands/config/model.ts
+++ b/src/commands/config/model.ts
@@ -1,6 +1,7 @@
 import {
   SlashCommandBuilder,
   type ChatInputCommandInteraction,
+  type AutocompleteInteraction,
   MessageFlags,
 } from "discord.js";
 import { redis } from "../../utils/redis.js";
@@ -14,14 +15,20 @@ export default {
         .setName("model")
         .setDescription("The model to use")
         .setRequired(true)
-        .setChoices(
-          Object.keys(MODELS).map((model) => ({
-            name: model === DEFAULT_MODEL ? "* " + model : model,
-            value: model,
-          }))
-        )
+        .setAutocomplete(true)
     )
     .setDescription("Pick your preferred chat model"),
+  async autocomplete(interaction: AutocompleteInteraction) {
+    const focusedValue = interaction.options.getFocused();
+    const choices = Object.keys(MODELS).map((model) => ({
+      name: model === DEFAULT_MODEL ? "* " + model : model,
+      value: model,
+    }));
+    const filtered = choices.filter((choice) =>
+      choice.name.toLowerCase().includes(focusedValue.toLowerCase())
+    );
+    await interaction.respond(filtered.slice(0, 25));
+  },
   async execute(interaction: ChatInputCommandInteraction) {
     const preferredModel = interaction.options.getString("model");
     if (!preferredModel) {
@@ -31,6 +38,15 @@ export default {
       });
       return;
     }
+    // Check if the selected model is valid (in case they bypassed autocomplete)
+    if (!Object.keys(MODELS).includes(preferredModel)) {
+       await interaction.reply({
+        content: "Invalid model selected.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
     redis.set(`user:${interaction.user.id}:model`, preferredModel);
     await interaction.reply({
       content: `Set your preferred model to ${preferredModel}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ import {
 export interface CommandType {
   data: SlashCommandBuilder;
   execute: (interaction: Interaction) => void;
-  autocomplete: (interaction: Interaction) => void;
+  autocomplete?: (interaction: Interaction) => void;
 }
 
 export interface GuessGame {


### PR DESCRIPTION
Updates the /model command to use autocomplete instead of hardcoded string choices. This allows for dynamic filtering and better UX with many models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added autocomplete suggestions when selecting a model configuration option, displaying up to 25 relevant matches as you type.

* **Bug Fixes**
  * Added validation to prevent invalid model selections, providing clear feedback if an unsupported model is chosen.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->